### PR TITLE
PLATFORM-3791: Force use of TLS 1.2

### DIFF
--- a/OauthApplicationClient.cs
+++ b/OauthApplicationClient.cs
@@ -224,7 +224,8 @@ namespace pokitdokcsharp
 			this._tokenRefresh = tokenRefresh;
             this._scope = scope;
             this._authCode = authCode;
-		}
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
+        }
 
 		/// <summary>
 		/// Get an access token and setup a timer to refresh the token

--- a/OauthApplicationClient.cs
+++ b/OauthApplicationClient.cs
@@ -224,6 +224,8 @@ namespace pokitdokcsharp
 			this._tokenRefresh = tokenRefresh;
             this._scope = scope;
             this._authCode = authCode;
+
+            // Force use of TLS 1.2
             ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
         }
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Runtime.CompilerServices;
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
-[assembly: AssemblyVersion ("0.5.*")]
+[assembly: AssemblyVersion("0.6.*")]
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]

--- a/pokitdok-csharp.csproj
+++ b/pokitdok-csharp.csproj
@@ -7,6 +7,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>pokitdokcsharp</RootNamespace>
     <AssemblyName>pokitdok-csharp</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,6 +28,7 @@
     </CustomCommands>
     <DocumentationFile>bin\Debug\pokitdok-csharp.xml</DocumentationFile>
     <Commandlineparameters>mono packages/NUnit.Runners.2.6.4/tools/nunit-console.exe bin/Debug/pokitdok-csharp.dll</Commandlineparameters>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>full</DebugType>
@@ -35,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <PlatformTarget>x86</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -47,6 +51,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -56,6 +61,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">


### PR DESCRIPTION
This PR update the .Net version to 4.5 and forces the use of TLS 1.2. 