### PR TITLE
Correct version number

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Runtime.CompilerServices;
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
-[assembly: AssemblyVersion("0.6.*")]
+[assembly: AssemblyVersion("1.17.*")]
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.
 //[assembly: AssemblyDelaySign(false)]


### PR DESCRIPTION
Previous version number was 0.5, so I bumped to 0.6. After checking
nuget and codeplex, looks like our current version is 1.16, so making
the appropriate adjustment to 1.17.