### PR TITLE
Improve client IDisposable implementation

### DIFF
--- a/OauthApplicationClient.cs
+++ b/OauthApplicationClient.cs
@@ -203,7 +203,7 @@ namespace pokitdokcsharp
     /// Oauth 2.0 Client implementing Client Credentials Grant Authorization
     ///		http://tools.ietf.org/html/rfc6749#section-4.4
     /// </summary>
-    public class OauthApplicationClient
+    public class OauthApplicationClient : IDisposable
     {
         /// <summary>
         /// The default http request timeout.
@@ -234,6 +234,37 @@ namespace pokitdokcsharp
         TokenRefreshDelegate _tokenRefresh = null;
 
         private ResponseData _responseData = new ResponseData();
+
+
+        /// <summary>
+        /// Dispose of authentication resources
+        /// </summary>
+        ~OauthApplicationClient()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this); 
+        }
+
+        private bool disposed = false;
+        /// <summary>
+        /// Protect against scenarios where the object has already been disposed of, 
+        /// but the GC has not processed the object. Avoids disposing the object twice.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed) { 
+                if (disposing) { 
+                    DeAuthenticate();
+                    _accessTokenRenewer?.Dispose();
+                    disposed = true; 
+                }
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="pokitdokcsharp.OauthApplicationClient"/> class.

--- a/PlatformClient.cs
+++ b/PlatformClient.cs
@@ -21,7 +21,7 @@ namespace pokitdokcsharp
     ///		Consumes the REST based PokitDok platform API
     ///		https://platform.pokitdok.com/documentation/v4#/#overview
     /// </summary>
-    public class PlatformClient: OauthApplicationClient, IDisposable
+    public class PlatformClient: OauthApplicationClient
     {
         /// <summary>
         /// The default PokitDok API site url.
@@ -115,17 +115,6 @@ namespace pokitdokcsharp
             this.UserAgent = string.Format("csharp-pokitdok/{0}", typeof(PlatformClient).Assembly.GetName().Version);
         }
 
-        ~PlatformClient()
-        {
-            Dispose();
-        }
-
-        public void Dispose()
-        {
-            DeAuthenticate();
-
-            _accessTokenRenewer?.Dispose();
-        }
 
         /// <summary>
         /// Init this instance.

--- a/tests/PlatformClientTest.cs
+++ b/tests/PlatformClientTest.cs
@@ -249,4 +249,23 @@ public class PlatformClientTest
 
         Assert.IsTrue(raised); 
     }
+
+    /// <summary>
+    /// Verify that the GC does not dispose of an already disposed of object.
+    /// </summary>
+    [Test]
+    public void TestPlatformClientDisposeOnlyOnce()
+    {
+
+        PlatformClient client = new PlatformClient("", "");
+        try
+        {
+            client.eligibility(new Dictionary<string, object> { });
+        }
+        catch (PokitDokException) { }
+
+        client.Dispose();
+        GC.Collect(); 
+        
+    }
 }


### PR DESCRIPTION
The client Dispose() method was getting called twice under some circumstances. This change: 
- Ensures that no network requests will be made during the client's Finalizer() method
- Moves the Disposable interface to the OAuthApplicationClient.cs (instead of the PlatformClient.cs). 